### PR TITLE
fix: suppress warning when executing dbt cmd

### DIFF
--- a/lua/dbtpal/config.lua
+++ b/lua/dbtpal/config.lua
@@ -13,6 +13,7 @@ M.defaults = {
     pre_cmd_args = {
         "--use-colors",
         "--printer-width=10",
+        "--quiet",
     },
 }
 


### PR DESCRIPTION
I was trying to use this plugins on a project, and I received json_parse errors. The project I was working on had `dbt_project.yml` config not up to date to the dbt version installed.

```
Error executing vim.schedule lua callback: Vim:E474: Unidentified byte: ^[[0m15:55:25  [^[[33mWARN
stack traceback:
        [C]: in function 'json_decode'
        ...m/site/pack/packer/start/dbtpal/lua/dbtpal/telescope.lua:25: in function 'entry_maker'
        ...scope.nvim/lua/telescope/finders/async_static_finder.lua:17: in function 'new_table'
        ...m/site/pack/packer/start/dbtpal/lua/dbtpal/telescope.lua:20: in function 'dbt_models'
        ...m/site/pack/packer/start/dbtpal/lua/dbtpal/telescope.lua:65: in function <...m/site/pack/packer/start/dbtpal/lua/dbtpal/telescope.lua:65>
```

When we consume a dbt command output, a json is expected. 
Warnings are output by the dbt cli, before the json in plain text. This commit silence them for all commands.

I corrected them and it fixes the issue, but I think this plug should aim to work regardless or provide a better error handling around that.
