### PR TITLE
feat: add dbt_picker_upstream and dbt_picker_downstream for relative model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ use {
         { "<leader>dtf", "<cmd>DbtTest<cr>" },
         { "<leader>dm", "<cmd>lua require('dbtpal.telescope').dbt_picker()<cr>" },
         { "<leader>du", "<cmd>lua require('dbtpal.telescope').dbt_picker_upstream()<cr>" },
-        { "<leader>dd", "<cmd>lua require('dbtpal.telescope').dbt_picker_downstream" },
+        { "<leader>dd", "<cmd>lua require('dbtpal.telescope').dbt_picker_downstream()<cr>" },
     },
     config = function()
         require("dbtpal").setup({

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ use {
         vim.keymap.set("n", "<leader>drp", dbt.run_all)
         vim.keymap.set("n", "<leader>dtf", dbt.test)
         vim.keymap.set("n", "<leader>dm", require("dbtpal.telescope").dbt_picker)
-        vim.keymap.set("n", "<leader>dmu", require("dbtpal.telescope").dbt_picker_upstream)
-        vim.keymap.set("n", "<leader>dmd", require("dbtpal.telescope").dbt_picker_downstream)
+        vim.keymap.set("n", "<leader>dd", require("dbtpal.telescope").dbt_picker_upstream)
+        vim.keymap.set("n", "<leader>du", require("dbtpal.telescope").dbt_picker_downstream)
 
         -- Enable Telescope Extension
         require("telescope").load_extension("dbtpal")
@@ -96,8 +96,8 @@ use {
         { "<leader>drp", "<cmd>DbtRunAll<cr>" },
         { "<leader>dtf", "<cmd>DbtTest<cr>" },
         { "<leader>dm", "<cmd>lua require('dbtpal.telescope').dbt_picker()<cr>" },
-        { "<leader>dmu", "<cmd>lua require('dbtpal.telescope').dbt_picker_upstream()<cr>" },
-        { "<leader>dmd", "<cmd>lua require('dbtpal.telescope').dbt_picker_downstream" },
+        { "<leader>du", "<cmd>lua require('dbtpal.telescope').dbt_picker_upstream()<cr>" },
+        { "<leader>dd", "<cmd>lua require('dbtpal.telescope').dbt_picker_downstream" },
     },
     config = function()
         require("dbtpal").setup({

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ use {
         vim.keymap.set("n", "<leader>drp", dbt.run_all)
         vim.keymap.set("n", "<leader>dtf", dbt.test)
         vim.keymap.set("n", "<leader>dm", require("dbtpal.telescope").dbt_picker)
+        vim.keymap.set("n", "<leader>dmu", require("dbtpal.telescope").dbt_picker_upstream)
+        vim.keymap.set("n", "<leader>dmd", require("dbtpal.telescope").dbt_picker_downstream)
 
         -- Enable Telescope Extension
         require("telescope").load_extension("dbtpal")
@@ -94,6 +96,8 @@ use {
         { "<leader>drp", "<cmd>DbtRunAll<cr>" },
         { "<leader>dtf", "<cmd>DbtTest<cr>" },
         { "<leader>dm", "<cmd>lua require('dbtpal.telescope').dbt_picker()<cr>" },
+        { "<leader>dmu", "<cmd>lua require('dbtpal.telescope').dbt_picker_upstream()<cr>" },
+        { "<leader>dmd", "<cmd>lua require('dbtpal.telescope').dbt_picker_downstream" },
     },
     config = function()
         require("dbtpal").setup({

--- a/doc/dbtpal.txt
+++ b/doc/dbtpal.txt
@@ -79,8 +79,8 @@ Install using your favorite plugin manager:
             vim.keymap.set("n", "<leader>drp", dbt.run_all)
             vim.keymap.set("n", "<leader>dtf", dbt.test)
             vim.keymap.set("n", "<leader>dm", require("dbtpal.telescope").dbt_picker)
-            vim.keymap.set("n", "<leader>dmu", require("dbtpal.telescope").dbt_picker_upstream)
-            vim.keymap.set("n", "<leader>dmd", require("dbtpal.telescope").dbt_picker_downstream)
+            vim.keymap.set("n", "<leader>du", require("dbtpal.telescope").dbt_picker_upstream)
+            vim.keymap.set("n", "<leader>dd", require("dbtpal.telescope").dbt_picker_downstream)
     
             -- Enable Telescope Extension
             require("telescope").load_extension("dbtpal")
@@ -110,8 +110,8 @@ Show configuration… ~
             { "<leader>drp", "<cmd>DbtRunAll<cr>" },
             { "<leader>dtf", "<cmd>DbtTest<cr>" },
             { "<leader>dm", "<cmd>lua require('dbtpal.telescope').dbt_picker()<cr>" },
-            { "<leader>dmu", "<cmd>lua require('dbtpal.telescope').dbt_picker_upstream()<cr>" },
-            { "<leader>dmd", "<cmd>lua require('dbtpal.telescope').dbt_picker_downstream()<cr>" },
+            { "<leader>du", "<cmd>lua require('dbtpal.telescope').dbt_picker_upstream()<cr>" },
+            { "<leader>dd", "<cmd>lua require('dbtpal.telescope').dbt_picker_downstream()<cr>" },
         },
         config = function()
             require("dbtpal").setup({

--- a/doc/dbtpal.txt
+++ b/doc/dbtpal.txt
@@ -79,6 +79,8 @@ Install using your favorite plugin manager:
             vim.keymap.set("n", "<leader>drp", dbt.run_all)
             vim.keymap.set("n", "<leader>dtf", dbt.test)
             vim.keymap.set("n", "<leader>dm", require("dbtpal.telescope").dbt_picker)
+            vim.keymap.set("n", "<leader>dmu", require("dbtpal.telescope").dbt_picker_upstream)
+            vim.keymap.set("n", "<leader>dmd", require("dbtpal.telescope").dbt_picker_downstream)
     
             -- Enable Telescope Extension
             require("telescope").load_extension("dbtpal")
@@ -108,6 +110,8 @@ Show configuration… ~
             { "<leader>drp", "<cmd>DbtRunAll<cr>" },
             { "<leader>dtf", "<cmd>DbtTest<cr>" },
             { "<leader>dm", "<cmd>lua require('dbtpal.telescope').dbt_picker()<cr>" },
+            { "<leader>dmu", "<cmd>lua require('dbtpal.telescope').dbt_picker_upstream()<cr>" },
+            { "<leader>dmd", "<cmd>lua require('dbtpal.telescope').dbt_picker_downstream()<cr>" },
         },
         config = function()
             require("dbtpal").setup({

--- a/lua/dbtpal/telescope.lua
+++ b/lua/dbtpal/telescope.lua
@@ -40,20 +40,19 @@ M.dbt_models = function(tbl, opts)
         :find()
 end
 
--- commands arguments like dbt `--select` require relative path to model from dbt project directory
-local _model_relative_path_to_dbt = function()
-    local b_full = vim.fn.expand "%:p"
-    local b_relative = b_full:sub(#config.options.path_to_dbt_project + 1)
-    if b_relative:sub(1, 1) == "/" then b_relative = b_relative:sub(2) end
-    return b_relative
+local _current_model_name = function()
+    -- `%` represents the current file.
+    -- `:t` extracts just the file name (tail), excluding the directory path.
+    -- `:r` removes the file extension from the file name.
+    return vim.fn.expand "%:t:r"
 end
 
 local _picker = function(opts, additional_args)
-    additional_args = additional_args or {}
-
     local cmd = "ls"
     local args = { "--resource-type=model", "--output=json", "--quiet" }
-    args = vim.tbl_extend("force", args, additional_args)
+
+    additional_args = additional_args or {}
+    vim.list_extend(args, additional_args)
 
     if config.options.path_to_dbt_project == "" then
         local bpath = vim.fn.expand "%:p:h"
@@ -92,14 +91,14 @@ end
 M.dbt_picker = function(opts) _picker(opts) end
 
 M.dbt_picker_downstream = function(opts)
-    local b_relative = _model_relative_path_to_dbt()
-    local additional_args = { "--select=" .. b_relative .. "+" }
+    local model = _current_model_name()
+    local additional_args = { "--select=" .. model .. "+" }
     _picker(opts, additional_args)
 end
 
 M.dbt_picker_upstream = function(opts)
-    local b_relative = _model_relative_path_to_dbt()
-    local additional_args = { "--select=+" .. b_relative }
+    local model = _current_model_name()
+    local additional_args = { "--select=+" .. model }
     _picker(opts, additional_args)
 end
 


### PR DESCRIPTION
Introduces `dbt_picker_upstream` and `dbt_picker_downstream` Telescope pickers.

Makes use of the `--select` option of the `dbt ls` command. By passing in the relative file path, to the dbt project, of the current buffer, we can determine the upstream and downstream models with either a prefix or suffix `+`.

Definitely open to feedback on the implementation, I think it might be possible for us to implement a generic solution where the user can provide the `--select` syntax themselves, and `_picker` might be able to be cleaned up a bit more. 