### PR TITLE
Remove default keymaps and make cmd additions optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ use {
             protect_compiled_files = true,
 
             -- additional flags to include at the beginning of the rendered dbt command
-            pre_cmd_args = {
-                "--printer-width=10",
-            },
+            pre_cmd_args = {},
 
             -- additional flags to include at the end of the rendered dbt command
             post_cmd_args = {},
@@ -118,9 +116,7 @@ use {
             include_log_level = true,
             extended_path_search = true,
             protect_compiled_files = true,
-            pre_cmd_args = {
-                "--printer-width=10",
-            },
+            pre_cmd_args = {},
             post_cmd_args = {},
         })
         require("telescope").load_extension("dbtpal")
@@ -229,7 +225,7 @@ The following options are available:
 | include_profiles_dir     | Include `--profiles-dir` flag in dbt command                             | `true`                             |
 | include_project_dir      | Include `--project-dir` flag in dbt command                              | `true`                             |
 | include_log_level        | Include `--log-level=INFO` flag in dbt command                           | `true`                             |
-| pre_cmd_args             | Additional flags to include at the beginning of the rendered dbt command | `{"--printer-width=10"}`           |
+| pre_cmd_args             | Additional flags to include at the beginning of the rendered dbt command | `{}`                            |
 | porst_cmd_args           | Additional flags to include at the end of the rendered dbt command       | `{}`                               |
 
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,24 @@ use {
             -- Path to dbt profiles directory
             path_to_dbt_profiles_dir = vim.fn.expand("~/.dbt"),
 
+            -- flags to include in dbt command
+            include_profiles_dir = true,  -- --profiles-dir
+            include_project_dir = true,  -- --project-dir
+            include_log_level = true,  --  --log-level=INFO
+
             -- Search for ref/source files in macros and models folders
             extended_path_search = true,
 
             -- Prevent modifying sql files in target/(compiled|run) folders
             protect_compiled_files = true,
+
+            -- additional flags to include at the beginning of the rendered dbt command
+            pre_cmd_args = {
+                "--printer-width=10",
+            },
+
+            -- additional flags to include at the end of the rendered dbt command
+            post_cmd_args = {},
         })
 
         -- Setup key mappings
@@ -100,8 +113,15 @@ use {
             path_to_dbt = "dbt",
             path_to_dbt_project = "",
             path_to_dbt_profiles_dir = vim.fn.expand("~/.dbt"),
+            include_profiles_dir = true,
+            include_project_dir = true,
+            include_log_level = true,
             extended_path_search = true,
             protect_compiled_files = true,
+            pre_cmd_args = {
+                "--printer-width=10",
+            },
+            post_cmd_args = {},
         })
         require("telescope").load_extension("dbtpal")
     end,
@@ -199,13 +219,19 @@ require("dbtpal").setup({ ... })
 
 The following options are available:
 
-| Option                   | Description                                              | Default                            |
-| ------                   | -----------                                              | -------                            |
-| path_to_dbt              | Path to the dbt executable                               | `dbt` (i.e. dbt in the local path) |
-| path_to_dbt_project      | Path to the dbt project                                  | `""` (auto-detect)                 |
-| path_to_dbt_profiles_dir | Path to dbt profiles directory                           | `"~/.dbt"`                         |
-| extended_path_search     | Search for ref/source files in macros and models folders | `true`                             |
-| protect_compiled_files   | Prevent modifying sql files in target/(compiled\|run) folders | `true`                    |
+| Option                   | Description                                                              | Default                            |
+| ------                   | -----------                                                              | -------                            |
+| path_to_dbt              | Path to the dbt executable                                               | `dbt` (i.e. dbt in the local path) |
+| path_to_dbt_project      | Path to the dbt project                                                  | `""` (auto-detect)                 |
+| path_to_dbt_profiles_dir | Path to dbt profiles directory                                           | `"~/.dbt"`                         |
+| extended_path_search     | Search for ref/source files in macros and models folders                 | `true`                             |
+| protect_compiled_files   | Prevent modifying sql files in target/(compiled\|run) folders            | `true`                             |
+| include_profiles_dir     | Include `--profiles-dir` flag in dbt command                             | `true`                             |
+| include_project_dir      | Include `--project-dir` flag in dbt command                              | `true`                             |
+| include_log_level        | Include `--log-level=INFO` flag in dbt command                           | `true`                             |
+| pre_cmd_args             | Additional flags to include at the beginning of the rendered dbt command | `{"--printer-width=10"}`           |
+| porst_cmd_args           | Additional flags to include at the end of the rendered dbt command       | `{}`                               |
+
 
 
 ### Misc

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ The following options are available:
 | protect_compiled_files   | Prevent modifying sql files in target/(compiled\|run) folders            | `true`                             |
 | include_profiles_dir     | Include `--profiles-dir` flag in dbt command                             | `true`                             |
 | include_project_dir      | Include `--project-dir` flag in dbt command                              | `true`                             |
-| include_log_level        | Include `--log-level=INFO` flag in dbt command                           | `true`                             |
+| include_log_level        | Include `--log-level=INFO` flag in dbt command (only for dbt >= 1.5)     | `true`                             |
 | pre_cmd_args             | Additional flags to include at the beginning of the rendered dbt command | `{}`                            |
 | porst_cmd_args           | Additional flags to include at the end of the rendered dbt command       | `{}`                               |
 

--- a/lua/dbtpal/commands.lua
+++ b/lua/dbtpal/commands.lua
@@ -15,25 +15,30 @@ M.build_path_args = function(cmd, args)
     local dbt_path = config.options.path_to_dbt
     local dbt_project = config.options.path_to_dbt_project
     local dbt_profile = config.options.path_to_dbt_profiles_dir
+    local include_profiles_dir = config.options.include_profiles_dir
+    local include_project_dir = config.options.include_project_dir
+    local include_log_level = config.options.include_log_level
 
     local cmd_args = {}
 
     -- TODO: make this configurable
     local pre_cmd_args = config.options.pre_cmd_args or {}
+    local post_cmd_args = config.options.post_cmd_args or {}
 
-    if get_dbt_version() ~= nil and get_dbt_version() >= 1.5 then
-        log.debug "dbt version >= 1.5, using --log-level=INFO"
-        vim.list_extend(pre_cmd_args, { "--log-level=INFO" })
-    end
-
-    local post_cmd_args = {}
-    if dbt_profile ~= "v:null" then
+    if include_profiles_dir and dbt_profile ~= "v:null" then
         table.insert(post_cmd_args, "--profiles-dir")
         table.insert(post_cmd_args, dbt_profile)
     end
 
-    table.insert(post_cmd_args, "--project-dir")
-    table.insert(post_cmd_args, dbt_project)
+    if include_project_dir and dbt_project ~= "v:null" then
+        table.insert(post_cmd_args, "--project-dir")
+        table.insert(post_cmd_args, dbt_project)
+    end
+
+    if include_log_level and get_dbt_version() ~= nil and get_dbt_version() >= 1.5 then
+        log.debug "dbt version >= 1.5, using --log-level=INFO"
+        table.insert(post_cmd_args, "--log-level=INFO")
+    end
 
     vim.list_extend(cmd_args, pre_cmd_args)
     vim.list_extend(cmd_args, { cmd })

--- a/lua/dbtpal/config.lua
+++ b/lua/dbtpal/config.lua
@@ -6,6 +6,10 @@ M.defaults = {
     path_to_dbt_project = "",
     path_to_dbt_profiles_dir = vim.fn.expand "~/.dbt",
 
+    include_profiles_dir = true,
+    include_project_dir = true,
+    include_log_level = true,
+
     custom_dbt_syntax_enabled = true,
     extended_path_search = true,
     protect_compiled_files = true,
@@ -13,6 +17,7 @@ M.defaults = {
     pre_cmd_args = {
         "--printer-width=10",
     },
+    post_cmd_args = {},
 
     env = {
         ["DBT_LOG_LEVEL"] = "NONE",

--- a/lua/dbtpal/config.lua
+++ b/lua/dbtpal/config.lua
@@ -14,9 +14,7 @@ M.defaults = {
     extended_path_search = true,
     protect_compiled_files = true,
 
-    pre_cmd_args = {
-        "--printer-width=10",
-    },
+    pre_cmd_args = {},
     post_cmd_args = {},
 
     env = {

--- a/lua/dbtpal/init.lua
+++ b/lua/dbtpal/init.lua
@@ -43,10 +43,6 @@ vim.api.nvim_create_user_command("DbtCompile", function() main.compile() end, { 
 
 vim.api.nvim_create_user_command("DbtBuild", function() main.build() end, { nargs = 0 })
 
--- Debug keybindings to run dbt
-vim.api.nvim_set_keymap("n", "<leader>dr", ":lua require('dbtpal').run()<CR>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("n", "<leader>dt", ":lua require('dbtpal').test()<CR>", { noremap = true, silent = true })
-
 local ok, _ = pcall(require, "telescope")
 if ok then M.dbt_picker = require("dbtpal.telescope").dbt_picker end
 return M

--- a/lua/dbtpal/projects.lua
+++ b/lua/dbtpal/projects.lua
@@ -28,7 +28,14 @@ M.detect_dbt_project_dir = function(bpath)
 end
 
 M._get_package_name = function()
-    local name = vim.fn.system [[grep -E 'name: \S+' ~/projects/clients/causal/internal_dbt/dbt_project.yml]]
+    local dbt_project_dir = function()
+        if config.options.path_to_dbt_project ~= "" then
+            return config.options.path_to_dbt_project
+        else
+            return _find_project_dir()
+        end
+    end
+    local name = vim.fn.system [[grep -E 'name: \S+' ]] + dbt_project_dir()
     return string.match(name, [[name:%s+['"]([%w_]+)]])
 end
 


### PR DESCRIPTION
while configuring this plugin, i noticed a few issues that didnt play nice with my config:
1. there are forced keymaps that conflict with my keymaps and keymaps included by default in LazyVim
- i prefer to define my own keymaps in `keys` or have a config option to accept the default keymaps, but given that the readme suggests adding them to `keys` and then also force sets them in the plugin, i opted to just remove the forced keymaps

2. there were flags being passed into the dbt command at the beginning that were breaking my ability to use the plugin since my company uses a wrapper around dbt
- for this i added some config options to enable or disable these flags, and if included, moved them to the end of the command as they are flags so position does not matter

3. I added a configurable post cmd args that help me to be able to add flags to my dbt execution given the precommands are captured by the wrapper

4. i attempted to generalize the `_get_package_name` function (although i didnt see anywhere where it is used) as it seemed very specific to the creators environment, but i can remove this if it causes any issues, just seemed like something that wouldnt really work for anyone else so tried to make it more globally useful